### PR TITLE
Update start.sh

### DIFF
--- a/install/start.sh
+++ b/install/start.sh
@@ -15,7 +15,7 @@ en=$2
 #stty erase ^h
 setenforce 0
 
-centosV=`cat /etc/redhat-release|sed -r 's/.* ([0-9]+)\..*/\1/'`
+centosV=`cat /etc/redhat-release|sed -r 's/.* ([0-9]+)\.?.*/\1/'`
 
 if [ $centosV != 7 ] ; then 
     if [ $centosV != 8 ] ; then 


### PR DESCRIPTION
系统版本：CentOS Stream 8

您好，在使用方式三安装时候，会提示参数过多，对start.sh进行分析发现是因为一个正则的错误导致的。

![image-20240904124127254](https://bycsoss.oss-cn-hangzhou.aliyuncs.com/picgo/image-20240904124127254.png)
![image-20240904130707944](https://bycsoss.oss-cn-hangzhou.aliyuncs.com/picgo/image-20240904130707944.png)